### PR TITLE
Add 2in3 store

### DIFF
--- a/2in3/store.js
+++ b/2in3/store.js
@@ -1,0 +1,18 @@
+import { Store } from "svelte2/store.js";
+
+class Svelte3Store extends Store {
+    subscribe(fn) {
+        const { cancel } = this.on("state", ({ current }) => fn(current));
+
+        fn(this.get());
+
+        return cancel;
+    }
+
+    update(fn) {
+        this.set(fn(this.get()));
+    }
+}
+
+export default Svelte3Store;
+

--- a/2in3/store.js
+++ b/2in3/store.js
@@ -14,5 +14,5 @@ class Svelte3Store extends Store {
     }
 }
 
-export default Svelte3Store;
+export { Svelte3Store as Store };
 

--- a/2in3/tests/__snapshots__/store.test.js.snap
+++ b/2in3/tests/__snapshots__/store.test.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`2in3 store adapter should be able to reactively update from store values 1`] = `
+
+<div>
+  1 2 3
+</div>
+
+`;
+
+exports[`2in3 store adapter should be able to reactively update from store values 2`] = `
+
+<div>
+  1 3 4
+</div>
+
+`;
+
+exports[`2in3 store adapter should render derived store values 1`] = `
+
+<div>
+  1 2 3
+</div>
+
+`;
+
+exports[`2in3 store adapter should render derived store values 2`] = `
+
+<div>
+  1 3 4
+</div>
+
+`;
+
+exports[`2in3 store adapter should render extended store values 1`] = `
+
+<div>
+  1 2 {"one":1,"two":2}
+</div>
+
+`;
+
+exports[`2in3 store adapter should render extended store values 2`] = `
+
+<div>
+  1 3 {"one":1,"two":2}
+</div>
+
+`;
+
+exports[`2in3 store adapter should render simple store values 1`] = `
+
+<div>
+  1 2
+</div>
+
+`;
+
+exports[`2in3 store adapter should render simple store values 2`] = `
+
+<div>
+  1 3
+</div>
+
+`;

--- a/2in3/tests/__snapshots__/store.test.js.snap
+++ b/2in3/tests/__snapshots__/store.test.js.snap
@@ -16,6 +16,14 @@ exports[`2in3 store adapter should be able to reactively update from store value
 
 `;
 
+exports[`2in3 store adapter should have a .update() that works 1`] = `
+Object {
+  "one": 1,
+  "three": 3,
+  "two": 2,
+}
+`;
+
 exports[`2in3 store adapter should render derived store values 1`] = `
 
 <div>

--- a/2in3/tests/specimens/derived.svelte
+++ b/2in3/tests/specimens/derived.svelte
@@ -1,0 +1,14 @@
+<div>
+    {$store.one}
+    {$store.two}
+    {$sum}
+</div>
+
+<script>
+import { derived } from "svelte/store";
+import { simple as store } from "./store.js";
+
+const sum = derived(store, ({ one, two }, set) => {
+    set(one + two);
+});
+</script>

--- a/2in3/tests/specimens/extended.svelte
+++ b/2in3/tests/specimens/extended.svelte
@@ -1,0 +1,11 @@
+<div>
+    {$store.one}
+    {$store.two}
+    {JSON.stringify(test)}
+</div>
+
+<script>
+import { extended as store } from "./store.js";
+
+let test = store.test();
+</script>

--- a/2in3/tests/specimens/reactive.svelte
+++ b/2in3/tests/specimens/reactive.svelte
@@ -1,0 +1,11 @@
+<div>
+    {$store.one}
+    {$store.two}
+    {sum}
+</div>
+
+<script>
+import { simple as store } from "./store.js";
+
+$: sum = $store.one + $store.two;
+</script>

--- a/2in3/tests/specimens/simple.svelte
+++ b/2in3/tests/specimens/simple.svelte
@@ -1,0 +1,8 @@
+<div>
+    {$store.one}
+    {$store.two}
+</div>
+
+<script>
+import { simple as store } from "./store.js";
+</script>

--- a/2in3/tests/specimens/store.js
+++ b/2in3/tests/specimens/store.js
@@ -1,11 +1,11 @@
-import Adapter from "../../store.js";
+import { Store } from "../../store.js";
 
-const simple = new Adapter({
+const simple = new Store({
     one : 1,
     two : 2,
 });
 
-class ExtendedStore extends Adapter {
+class ExtendedStore extends Store {
     test() {
         return this.get();
     }

--- a/2in3/tests/specimens/store.js
+++ b/2in3/tests/specimens/store.js
@@ -1,0 +1,22 @@
+import Adapter from "../../store.js";
+
+const simple = new Adapter({
+    one : 1,
+    two : 2,
+});
+
+class ExtendedStore extends Adapter {
+    test() {
+        return this.get();
+    }
+}
+
+const extended = new ExtendedStore({
+    one : 1,
+    two : 2,
+});
+
+export {
+    simple,
+    extended,
+};

--- a/2in3/tests/store.test.js
+++ b/2in3/tests/store.test.js
@@ -90,4 +90,10 @@ describe("2in3 store adapter", () => {
         
         expect(root.innerHTML).toMatchSnapshot();
     });
+
+    it("should have a .update() that works", async () => {
+        simple.update(({ one, two }) => ({ three : one + two }));
+
+        expect(simple.get()).toMatchSnapshot();
+    });
 });

--- a/2in3/tests/store.test.js
+++ b/2in3/tests/store.test.js
@@ -1,0 +1,93 @@
+"use strict";
+import { tick } from "svelte";
+
+import { simple, extended } from "./specimens/store.js";
+
+describe("2in3 store adapter", () => {
+    const { default : Simple } = require("./specimens/simple.svelte");
+    const { default : Extended } = require("./specimens/extended.svelte");
+    const { default : Derived } = require("./specimens/derived.svelte");
+    const { default : Reactive } = require("./specimens/reactive.svelte");
+    
+    let root;
+
+    beforeEach(() => {
+        root = document.createElement("div");
+    });
+
+    afterEach(() => {
+        simple.set({
+            one : 1,
+            two : 2,
+        });
+        
+        extended.set({
+            one : 1,
+            two : 2,
+        });
+    });
+
+    it("should render simple store values", async () => {
+        new Simple({
+            target : root
+        });
+        
+        expect(root.innerHTML).toMatchSnapshot();
+        
+        simple.set({
+            two : 3
+        });
+
+        await tick();
+        
+        expect(root.innerHTML).toMatchSnapshot();
+    });
+    
+    it("should render extended store values", async () => {
+        new Extended({
+            target : root
+        });
+        
+        expect(root.innerHTML).toMatchSnapshot();
+        
+        extended.set({
+            two : 3
+        });
+
+        await tick();
+        
+        expect(root.innerHTML).toMatchSnapshot();
+    });
+
+    it("should render derived store values", async () => {
+        new Derived({
+            target : root
+        });
+        
+        expect(root.innerHTML).toMatchSnapshot();
+        
+        simple.set({
+            two : 3
+        });
+
+        await tick();
+        
+        expect(root.innerHTML).toMatchSnapshot();
+    });
+    
+    it("should be able to reactively update from store values", async () => {
+        new Reactive({
+            target : root
+        });
+        
+        expect(root.innerHTML).toMatchSnapshot();
+        
+        simple.set({
+            two : 3
+        });
+
+        await tick();
+        
+        expect(root.innerHTML).toMatchSnapshot();
+    });
+});

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Use svelte 2 features inside svelte 3, and use svelte 3 features inside svelte 2
 
 | Feature | Svelte 3 in 2 | Svelte 2 in 3 |
 | ---: | :---: | :---: |
-| Stores | ✔ | 💭 |
+| Stores | ✔ | ✔ |
 | Components | ✔ | 💭 |
 | Rollup Bundling | ✔ | ✔ |
 
@@ -96,7 +96,51 @@ s3w.subscribe((value) => {
 
 ### Svelte v2 in Svelte v3
 
-Still in progress
+#### Stores
+
+`svelte-translator/2in3/store.js` implements the v3 store contract (`.set()` is provided natively by v2 stores, it implements `.subscribe()` & `.update()`) in a class that extends `svelte/store.js` so it can be a drop-in replacement.
+
+Here's an example of how to make v2 stores usable in v3 components.
+
+```diff
+- import { Store } from "svelte/store.js";
++ import { Store } from "svelte-translator/2in3/store.js";
+```
+
+The `svelte-translator` version is fully functional in v3 components. You can use its values directly within the template, within the component `<script>` block either staticly or in reactive statements, and it can also be used as an input to any `derived` stores.
+
+It also remains a completely valid svelte v2 store that functions just as they always have in your v2 components.
+
+```js
+// my-store.js
+import { Store } from "svelte-translator/2in3/store.js";
+
+const store = new Store({
+    ...
+});
+
+export default store;
+```
+
+```html
+<!-- my-component.html -->
+<div>{$store.foo}</div>
+
+<p>
+{reactive}
+</p>
+
+<span>{$dstore}</span>
+
+<script>
+import store from "./my-store.js";
+import { derived } from "svelte/store";
+
+$: reactive = $store.foo + "ey";
+
+const dstore = derived(store, ($foo, set) => set(foo + "ey));
+</script>
+```
 
 ### Rollup bundling of Svelte v2 & Svelte v3
 


### PR DESCRIPTION
Makes any v2 store usable in v3, a drop-in replacement for `svelte/store.js`.