### PR TITLE
Split props out into a separate field

### DIFF
--- a/3in2/component.html
+++ b/3in2/component.html
@@ -6,13 +6,13 @@ export default {
         // svelte3 component to invoke
         component : false,
 
-        // All values are passed to the svelte3 component as props!
+        // props for the component
+        props : {},
     }),
 
     methods : {
         instantiate() {
-            const props = this.get();
-            const { component } = props;
+            const { component, props } = this.get();
             const { anchor } = this.refs;
 
             // Cleanup any previous component instance first
@@ -56,7 +56,7 @@ export default {
             }
 
             if(this.instance) {
-                return this.instance.$set(current);
+                return this.instance.$set(current.props);
             }
         });
     },

--- a/3in2/tests/component.test.js
+++ b/3in2/tests/component.test.js
@@ -29,7 +29,7 @@ describe("3in2 component wrapper", () => {
         expect(() => new Wrapper({
             target : root,
             data   : {
-                component : true
+                component : true,
             },
         })).toThrowErrorMatchingSnapshot();
     });
@@ -55,7 +55,9 @@ describe("3in2 component wrapper", () => {
             data : {
                 component : ComponentA,
 
-                a : "A",
+                props : {
+                    a : "A",
+                },
             },
         });
 
@@ -69,14 +71,18 @@ describe("3in2 component wrapper", () => {
             data : {
                 component : ComponentA,
 
-                a : "A",
+                props : {
+                    a : "A",
+                },
             },
         });
 
         expect(root.innerHTML).toMatchSnapshot();
 
         wrapper.set({
-            a : "A2",
+            props : {
+                a : "A2",
+            },
         });
 
         await wait();
@@ -91,7 +97,9 @@ describe("3in2 component wrapper", () => {
             data : {
                 component : ComponentA,
 
-                a : "A",
+                props : {
+                    a : "A",
+                },
             },
         });
 
@@ -99,7 +107,10 @@ describe("3in2 component wrapper", () => {
 
         wrapper.set({
             component : ComponentA,
-            a : "A2",
+
+            props : {
+                a : "A2",
+            },
         });
 
         await wait();
@@ -114,7 +125,9 @@ describe("3in2 component wrapper", () => {
             data : {
                 component : ComponentA,
 
-                a : "A",
+                props : {
+                    a : "A",
+                },
             },
         });
 
@@ -156,7 +169,7 @@ describe("3in2 component wrapper", () => {
                     class      : "class",
                     style      : "color: red;",
                     "data-foo" : "data-foo",
-                }
+                },
             },
         });
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ $> npm install svelte@latest
 Wrap up a v3 component so it can be included within a svelte2 component.
 
 ```html
-<Wrapper {...props} />
+<Wrapper {component} {props} />
 
 <script>
-import Component from "your-svelte3-component.svelte";
+import Component from "./svelte3-component.svelte";
 
 export default {
     components : {
@@ -52,20 +52,17 @@ export default {
 
     data : () => ({
         component : Component,
+        props     : {
+            // any props for the component
+        }
     }),
-
-    // This computed is here so that this component can essentially be invisible, it
-    // exists solvely to help the transition and can be removed once v2 is gone
-    computed : {
-        props : (state) => state,
-    },
 };
 ```
 
 | Data | Usage |
 | --- | --- |
 | `component` | The v3 component to wrap |
-| `...` | All other props on the component are passed directly to the v3 component |
+| `props` | Properties to set on the v3 component |
 
 #### Stores
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -902,9 +902,9 @@
       }
     },
     "@tivac/eslint-config": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@tivac/eslint-config/-/eslint-config-2.3.1.tgz",
-      "integrity": "sha512-o2r8opqSmJRw4NZJ8+jbxm6acxdkBssID7RVKWrXk3E67aDAnJV2j85X+mDNOPFbdoaM8kQSiu24wEFivLUuMA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@tivac/eslint-config/-/eslint-config-2.4.0.tgz",
+      "integrity": "sha512-GfVD41ApT2UTjUQbRIbgFj65o6/Nycp3ggUbaJW99NP8xiAjdngdRx6IbCy2sRLPgrpnv8KipG1U9EfL97gqyA==",
       "dev": true
     },
     "@types/babel__core": {
@@ -2594,9 +2594,9 @@
       }
     },
     "eslint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.0.tgz",
-      "integrity": "sha512-SrrIfcd4tOgsspOKTSwamuTOAMZOUigHQhVMrzNjz4/B9Za6SHQDIocMIyIDfwDgx6MhS15nS6HC8kumCV2qBQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.0.1.tgz",
+      "integrity": "sha512-DyQRaMmORQ+JsWShYsSg4OPTjY56u1nCjAmICrE8vLWqyLKxhFXOthwMj1SA8xwfrv0CofLNVnqbfyhwCkaO0w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -3008,9 +3008,9 @@
       }
     },
     "flatted": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
-      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.1.tgz",
+      "integrity": "sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==",
       "dev": true
     },
     "for-in": {
@@ -3931,7 +3931,6 @@
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-extglob": "^2.1.0"
           }
@@ -4359,8 +4358,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
@@ -6712,8 +6710,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
       "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "path-exists": {
       "version": "3.0.0",
@@ -7192,9 +7189,9 @@
       "dev": true
     },
     "rollup-plugin-node-resolve": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.0.4.tgz",
-      "integrity": "sha512-L/fGn+uZOCk/e3uNa3MITUCA3tXndcsaH0Bc7rq7v389vEXMXAYnmF0giEUWbhYxE7PyMGglByVrR8AeIP9klw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.1.0.tgz",
+      "integrity": "sha512-2hwwHNj0s8UEtUNT+lJq8rFWEznP7yJm3GCHBicadF6hiNX1aRARRZIjz2doeTlTGg/hOvJr4C/8+3k9Y/J5Hg==",
       "dev": true,
       "requires": {
         "@types/resolve": "0.0.8",
@@ -7762,9 +7759,9 @@
       }
     },
     "svelte": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.5.4.tgz",
-      "integrity": "sha512-NgMhBfmx5/Iatqmd0EWdGpYIjooai4GVGIqGCli8X5AKmXbqrci7h2yxE0VJcglYXxDNtPoF7ZhqpBRGbyr3lg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.6.1.tgz",
+      "integrity": "sha512-4TaCyB0nBgpsdLBZ8T0ovIgbVpNoCmXnPvBkJ0v1P9RYY2gcYd7Yv1FX+O7hW4Ak1v8uVSKh6WU0XBlN2oZXEw==",
       "dev": true
     },
     "svelte2": {

--- a/package.json
+++ b/package.json
@@ -22,27 +22,27 @@
   "author": "Pat Cavit <npm@patcavit.com>",
   "license": "MIT",
   "dependencies": {
-    "rollup-pluginutils": "^2.7.0"
+    "rollup-pluginutils": "^2.8.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-modules-commonjs": "^7.4.4",
-    "@tivac/eslint-config": "^2.3.1",
+    "@tivac/eslint-config": "^2.4.0",
     "babel-core": "^6.26.3",
-    "babel-eslint": "^10.0.1",
+    "babel-eslint": "^10.0.2",
     "babel-jest": "^24.8.0",
     "babel-plugin-add-module-exports": "^1.0.2",
     "conventional-changelog-cli": "^2.0.21",
-    "eslint": "^6.0.0",
-    "eslint-plugin-jest": "^22.5.1",
+    "eslint": "^6.0.1",
+    "eslint-plugin-jest": "^22.7.1",
     "jest": "^24.8.0",
     "jest-serializer-html": "^6.0.0",
     "p-immediate": "^3.1.0",
     "require-from-string": "^2.0.2",
-    "rollup": "^1.12.1",
+    "rollup": "^1.16.2",
     "rollup-plugin-hypothetical": "^2.1.0",
-    "rollup-plugin-node-resolve": "^5.0.0",
+    "rollup-plugin-node-resolve": "^5.1.0",
     "snapshot-diff": "^0.5.1",
-    "svelte": "^3.4.1",
+    "svelte": "^3.6.1",
     "svelte2": "npm:svelte@^2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Having it pass along everything leads to svelte complaining about unexpected props unless you define `export let component;` in every svelte3 component, which... no.

**this is a BREAKING CHANGE**